### PR TITLE
Fix for installing app into Tutor

### DIFF
--- a/lti_params_api/utils.py
+++ b/lti_params_api/utils.py
@@ -1,6 +1,7 @@
 """
 It will have helper methods for processing the LTI params.
 """
+from opaque_keys.edx.keys import UsageKey
 from xmodule.modulestore.django import modulestore
 
 
@@ -29,8 +30,6 @@ def get_block_data(usage_data):
     """
     This will return metadata of given LTI in dict format.
     """
-    from cms.djangoapps.contentstore.views.helpers import usage_key_with_run
-
     usage_key = usage_key_with_run(usage_data.get('component_id'))
 
     module_store = modulestore()
@@ -48,3 +47,12 @@ def get_block_data(usage_data):
     lti_info_dict['send_username'] = lti_info.ask_to_send_username
 
     return lti_info_dict
+
+
+def usage_key_with_run(usage_key_string):
+    """
+    Converts usage_key_string to a UsageKey, adding a course run if necessary
+    """
+    usage_key = UsageKey.from_string(usage_key_string)
+    usage_key = usage_key.replace(course_key=modulestore().fill_in_run(usage_key.course_key))
+    return usage_key


### PR DESCRIPTION
Fixes following error on tutor local quickstart:

StudioConfig doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.